### PR TITLE
Update GHC to 9.10 and Cabal to 3.12

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-ghcup set ghc 8.10.7
+ghcup set ghc 9.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.2.0.0"]
-        ghc: ["8.10.7"]
+        cabal: ["3.12"]
+        ghc: ["9.10"]
     # env:
     #   CONFIG: "--enable-tests --enable-benchmarks"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cabal v2-update
           cabal v2-freeze $CONFIG
-      - uses: actions/cache@v3.3.1
+      - uses: actions/cache@v4
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/oni-tech.cabal
+++ b/oni-tech.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.4
+cabal-version:       3.12
 name:                oni-tech
 version:             0.1.0
 homepage:            https://github.com/oni-tech/oni-tech.github.io#readme


### PR DESCRIPTION
- Update .envrc to use GHC 9.10
- Update oni-tech.cabal cabal-version to 3.12
- Update CI workflow to use GHC 9.10 and Cabal 3.12