### PR TITLE
Fix deprecated actions/cache version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cabal v2-update
           cabal v2-freeze $CONFIG
-      - uses: actions/cache@v3.3.1
+      - uses: actions/cache@v4
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}


### PR DESCRIPTION
Update actions/cache from v3.3.1 to v4 to avoid CI failures. The v3 versions are being deprecated and causing build failures.